### PR TITLE
 fix: prevent caching of partial responses and fix large video handling

### DIFF
--- a/config/worker-config.json
+++ b/config/worker-config.json
@@ -67,7 +67,7 @@
 				},
 				{
 					"name": "bynder",
-					"matcher": "^/m/([^/]+)/original/(.+\\.mp4)$",
+					"matcher": "^/m/([^/]+)/original/(.+\\.(mp4|mov))$",
 					"captureGroups": [
 						"hash",
 						"filename"
@@ -85,8 +85,8 @@
 							}
 						},
 						{
-							"type": "fallback",
-							"priority": 1,
+							"type": "remote",
+							"priority": 0,
 							"url": "https://ikea.getbynder.com",
 							"path": "m/${hash}/original/${filename}",
 							"auth": {
@@ -99,8 +99,8 @@
 							}
 						},
 						{
-							"type": "remote",
-							"priority": 0,
+							"type": "fallback",
+							"priority": 1,
 							"url": "https://r2.www.ikea.com",
 							"path": "m/${hash}/original/${filename}",
 							"auth": {

--- a/debug-ui/.astro/content.d.ts
+++ b/debug-ui/.astro/content.d.ts
@@ -45,6 +45,10 @@ declare module 'astro:content' {
 		collection: C;
 		slug: E;
 	};
+	export type ReferenceLiveEntry<C extends keyof LiveContentConfig['collections']> = {
+		collection: C;
+		id: string;
+	};
 
 	/** @deprecated Use `getEntry` instead. */
 	export function getEntryBySlug<
@@ -72,6 +76,13 @@ declare module 'astro:content' {
 		collection: C,
 		filter?: (entry: CollectionEntry<C>) => unknown,
 	): Promise<CollectionEntry<C>[]>;
+
+	export function getLiveCollection<C extends keyof LiveContentConfig['collections']>(
+		collection: C,
+		filter?: LiveLoaderCollectionFilterType<C>,
+	): Promise<
+		import('astro').LiveDataCollectionResult<LiveLoaderDataType<C>, LiveLoaderErrorType<C>>
+	>;
 
 	export function getEntry<
 		C extends keyof ContentEntryMap,
@@ -109,6 +120,10 @@ declare module 'astro:content' {
 			? Promise<DataEntryMap[C][E]> | undefined
 			: Promise<DataEntryMap[C][E]>
 		: Promise<CollectionEntry<C> | undefined>;
+	export function getLiveEntry<C extends keyof LiveContentConfig['collections']>(
+		collection: C,
+		filter: string | LiveLoaderEntryFilterType<C>,
+	): Promise<import('astro').LiveDataEntryResult<LiveLoaderDataType<C>, LiveLoaderErrorType<C>>>;
 
 	/** Resolve an array of entry references from the same collection */
 	export function getEntries<C extends keyof ContentEntryMap>(
@@ -152,5 +167,33 @@ declare module 'astro:content' {
 
 	type AnyEntryMap = ContentEntryMap & DataEntryMap;
 
+	type ExtractLoaderTypes<T> = T extends import('astro/loaders').LiveLoader<
+		infer TData,
+		infer TEntryFilter,
+		infer TCollectionFilter,
+		infer TError
+	>
+		? { data: TData; entryFilter: TEntryFilter; collectionFilter: TCollectionFilter; error: TError }
+		: { data: never; entryFilter: never; collectionFilter: never; error: never };
+	type ExtractDataType<T> = ExtractLoaderTypes<T>['data'];
+	type ExtractEntryFilterType<T> = ExtractLoaderTypes<T>['entryFilter'];
+	type ExtractCollectionFilterType<T> = ExtractLoaderTypes<T>['collectionFilter'];
+	type ExtractErrorType<T> = ExtractLoaderTypes<T>['error'];
+
+	type LiveLoaderDataType<C extends keyof LiveContentConfig['collections']> =
+		LiveContentConfig['collections'][C]['schema'] extends undefined
+			? ExtractDataType<LiveContentConfig['collections'][C]['loader']>
+			: import('astro/zod').infer<
+					Exclude<LiveContentConfig['collections'][C]['schema'], undefined>
+				>;
+	type LiveLoaderEntryFilterType<C extends keyof LiveContentConfig['collections']> =
+		ExtractEntryFilterType<LiveContentConfig['collections'][C]['loader']>;
+	type LiveLoaderCollectionFilterType<C extends keyof LiveContentConfig['collections']> =
+		ExtractCollectionFilterType<LiveContentConfig['collections'][C]['loader']>;
+	type LiveLoaderErrorType<C extends keyof LiveContentConfig['collections']> = ExtractErrorType<
+		LiveContentConfig['collections'][C]['loader']
+	>;
+
 	export type ContentConfig = typeof import("../src/content.config.mjs");
+	export type LiveContentConfig = never;
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -111,7 +111,7 @@
 				},
 				{
 					"binding": "VIDEO_TRANSFORMATIONS_CACHE",
-					"id": "3e02a673554b4964ae4b90cabdc684a9"
+					"id": "8e790768576242cc98fa3e4aa327f815"
 				},
 				{
 					"binding": "VIDEO_CACHE_KEY_VERSIONS",


### PR DESCRIPTION
  - Prevent KV storage of 206 partial responses to avoid corrupted cache entries
  - Fix "ReadableStream.tee() buffer limit exceeded" error for large videos
  - Filter out R2 sources from transformation retries to prevent URL corruption
  - Skip KV caching for videos exceeding 256MB transformation limit
  - Fix bynder matcher regex to properly match .mov files
  - Remove dead code in large video fallback handling

  These changes ensure that:
  1. Video players can properly seek without encountering corrupted partial responses
  2. Large videos (>256MB) are served directly without transformation
  3. R2 binding syntax won't corrupt URLs during retries
  4. Both .mp4 and .mov files are properly matched by the bynder origin
